### PR TITLE
SYN-6373 - Add Heroku Deploys, and update to Ruby 2.6.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+ruby '2.5.8'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '2.5.8'
+ruby '2.6.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.5.8p224
+   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,5 +200,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
+RUBY VERSION
+   ruby 2.5.8p224
+
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,5 @@
 class ApiController < ActionController::Base
-  protect_from_forgery :except => [:deploy_log]
+  protect_from_forgery :except => [:deploy_log, :heroku_deploy_log_hook]
   before_action :set_default_response_format
 
 
@@ -17,8 +17,31 @@ class ApiController < ActionController::Base
     return render json: {success: false, error_message: ex, backtrace: ex.backtrace}, status: :internal_server_error
   end
 
+  def heroku_deploy_log_hook
+    build_action = params.dig("action")
+    return render json: {success: true} unless build_action == "update" # only update has slug info we want, skip other actions
 
+    environment    = params.dig("data", "app", "name")
+    user_deploying = params.dig("actor", "email").split("@").first.strip
+    log_message    = params.dig("data", "slug", "commit_description")
+    commit         = params.dig("data", "slug", "commit")
+    branch         = Github.get_branch_from_commit(commit)
 
+    log_params = {
+      git_remote: environment, git_user: user_deploying, git_commit_message: log_message, commit_hash: commit, git_branch: branch
+    }
+
+    server = Server.find_by(git_remote: environment)
+    if server.present?
+      last_deploy_commit = server.deploys.last.try(:commit_hash)
+      server.deploys.create_from_params(server: server, params: log_params) unless last_deploy_commit == commit # prevent dupes from normal deploys
+      return render json: {success: true}
+    else
+      return render json: {success: false}, status: :unprocessable_entity
+    end
+  rescue => ex
+    return render json: {success: false, error_message: ex, backtrace: ex.backtrace}, status: :internal_server_error
+  end
 
   private
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,13 +19,14 @@ class ApiController < ActionController::Base
 
   def heroku_deploy_log_hook
     build_action = params.dig("action")
-    return render json: {success: true} unless build_action == "update" # only update has slug info we want, skip other actions
+    return render json: {success: true} unless build_action == "update" # only update action has slug info we want, skip other actions
 
     environment    = params.dig("data", "app", "name")
     user_deploying = params.dig("actor", "email").split("@").first.strip
-    log_message    = params.dig("data", "slug", "commit_description")
     commit         = params.dig("data", "slug", "commit")
-    branch         = Github.get_branch_from_commit(commit)
+    branch         = Github.get_branch_name_from_commit(commit)
+    log_message    = params.dig("data", "slug", "commit_description") # always seems to be "" when QA deploys
+    log_message    = log_message.present? ? log_message : Github.compare_changes_summary(branch || commit)
 
     heroku_log_params = {
       git_remote: environment, git_user: user_deploying, git_commit_message: log_message, commit_hash: commit, git_branch: branch
@@ -37,7 +38,7 @@ class ApiController < ActionController::Base
       server.deploys.create_from_params(server: server, params: heroku_log_params) unless last_deploy_commit == commit # prevent dupes from normal deploys
       return render json: {success: true}
     else
-      return render json: {success: false} #heroku will continue to retry for 72 hours unless we return 2XX response.
+      return render json: {success: false} # heroku will continue to retry for 72 hours unless we return 2XX response.
     end
   rescue => ex
     return render json: {success: false, error_message: ex, backtrace: ex.backtrace}, status: :internal_server_error

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -1,0 +1,49 @@
+module Github
+  class << self
+    API_KEY = ENV['GITHUB_API_KEY']
+    BASE_URL = "https://api.github.com"
+    HEADERS = {'Content-Type' => 'application/json',
+              'Authorization' => "token #{API_KEY}",
+              'Accept' => "application/vnd.github.v3+json"}
+
+    def make_request(path, method, body = {})
+      conn = Faraday.new(
+        url: "#{BASE_URL}/#{path}",
+        headers: HEADERS
+      )
+      response = conn.send(method) do |req|
+        req.body = body.to_json
+      end
+
+      JSON.load(response.body)
+    end
+
+    def get_path(path, body = {})
+      make_request(path, :get, body)
+    end
+
+    def get_commit(commit)
+      get_path("repos/RepairShopr/RepairShopr/commits/#{commit}")
+    end
+
+    def get_branches(page=1)
+      get_path("repos/RepairShopr/RepairShopr/branches?per_page=100&page=#{page}")
+    end
+
+    def get_branch_from_commit(commit)
+      page = 1
+      loop do
+        branches = get_branches(page)
+        break if branches.count == 0
+        branches.each do |branch|
+          branch_commit = branch.dig("commit", "sha")
+          branch_name = branch.dig("name")
+          return branch_name if branch_commit == commit
+        end
+        page += 1
+      end
+
+      return nil
+    end
+  end
+end

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -22,8 +22,8 @@ module Github
       make_request(path, :get, body)
     end
 
-    def compare_changes(commit_or_branch)
-      get_path("repos/RepairShopr/RepairShopr/compare/master...#{commit_or_branch}")
+    def compare_changes(commit_or_branch, base = 'master')
+      get_path("repos/RepairShopr/RepairShopr/compare/#{base}...#{commit_or_branch}")
     end
 
     def compare_changes_summary(commit_or_branch)

--- a/app/lib/github.rb
+++ b/app/lib/github.rb
@@ -22,6 +22,23 @@ module Github
       make_request(path, :get, body)
     end
 
+    def compare_changes(commit_or_branch)
+      get_path("repos/RepairShopr/RepairShopr/compare/master...#{commit_or_branch}")
+    end
+
+    def compare_changes_summary(commit_or_branch)
+      changes = compare_changes(commit_or_branch)
+      commits = changes.dig('commits')
+      summary = ""
+
+      commits.each do |commit|
+        name = commit.dig('commit', 'author', 'name')
+        message = commit.dig('commit', 'message').strip
+        summary << "#{name}: #{message}\n"
+      end
+      return summary
+    end
+
     def get_commit(commit)
       get_path("repos/RepairShopr/RepairShopr/commits/#{commit}")
     end
@@ -30,7 +47,11 @@ module Github
       get_path("repos/RepairShopr/RepairShopr/branches?per_page=100&page=#{page}")
     end
 
-    def get_branch_from_commit(commit)
+    def get_branch(branch_name)
+      get_path("repos/RepairShopr/RepairShopr/branches/#{branch_name}")
+    end
+
+    def get_branch_name_from_commit(commit)
       page = 1
       loop do
         branches = get_branches(page)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :server_deploys
   resources :servers
   post "/api/deploy_log", to: "api#deploy_log"
+  post "api/heroku_deploy_log_hook", to: "api#heroku_deploy_log_hook"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: "servers#index"
 


### PR DESCRIPTION
NEED TO ADD `GITHUB_API_KEY` to config vars 


1) we didn't have a ruby version specified in the gemfile.
- I did `heroku run "ruby -v"` and found out we were on 2.3.4p301
- I tried to install `2.3.4` and had trouble
- so I updated to `2.5.8` while I was here
- now updating to `2.6.6`

2) Now adding hook for heroku deploys (and looking to see if possible if heroku deploys support hooks) 