### PR TITLE
Fix Super Staging Slackbot - Can't verify CSRF token authenticity.

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -33,6 +33,7 @@ class ApiController < ActionController::Base
     }
 
     server = Server.find_by(git_remote: environment)
+    server ||= Server.find_by(git_remote: environment.split('-').last)
     if server.present?
       last_deploy_commit = server.deploys.last.try(:commit_hash)
       server.deploys.create_from_params(server: server, params: heroku_log_params) unless last_deploy_commit == commit # prevent dupes from normal deploys

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -13,7 +13,7 @@ class SlackController < ActionController::Base
     #  when you first test it out after "installing" it - just watch the payload it sends you to get the TOKEN and team domain for the authZ
 
     if params[:team_domain].present? && params[:token].present?
-      raise "BadAuth(tail logs to find it)" unless params[:team_domain] == ENV['SLACK_TEAM_DOMAIN'] && params[:token] == ENV['SLACK_TOKEN']
+      raise "BadAuth(tail logs to find it)" unless ActiveSupport::SecurityUtils.secure_compare(params[:team_domain], ENV['SLACK_TEAM_DOMAIN']) && ActiveSupport::SecurityUtils.secure_compare(params[:token], ENV['SLACK_TOKEN'])
 
       yellow = "#f89406"
       white  = "#ffffff"

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -4,7 +4,7 @@ class SlackController < ActionController::Base
   before_action :parse_payload, only: %i[super_staging_interactivity]
   before_action :verify_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
   before_action :initialize_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_tokenr
 
   def staging
 
@@ -185,7 +185,7 @@ release ss1
 
   def verify_super_staging
     # TODO validate with signature instead https://api.slack.com/docs/verifying-requests-from-slack#a_recipe_for_security
-    render json: {error: 'Invalid token'}, status: :unauthorized unless params[:token] == ENV['SUPER_STAGING_VERIFY_TOKEN']
+    render json: {error: 'Invalid token'}, status: :unauthorized unless ActiveSupport::SecurityUtils.secure_compare(params[:token], ENV['SUPER_STAGING_VERIFY_TOKEN'])
   end
 
   def parse_payload

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -185,7 +185,7 @@ release ss1
 
   def verify_super_staging
     # TODO validate with signature instead https://api.slack.com/docs/verifying-requests-from-slack#a_recipe_for_security
-    render json: {error: 'Invalid token'}, status: :unauthorized unless params[:token] == ENV['SUPER_STAGING_VERIFY_TOKEN']
+    render json: {error: 'Invalid token'}, status: :unauthorized unless Devise.secure_compare(params[:token], ENV['SUPER_STAGING_VERIFY_TOKEN'])
   end
 
   def parse_payload

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -4,7 +4,7 @@ class SlackController < ActionController::Base
   before_action :parse_payload, only: %i[super_staging_interactivity]
   before_action :verify_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
   before_action :initialize_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
-  skip_before_action :verify_authenticity_tokenr
+  skip_before_action :verify_authenticity_token
 
   def staging
 

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -185,7 +185,7 @@ release ss1
 
   def verify_super_staging
     # TODO validate with signature instead https://api.slack.com/docs/verifying-requests-from-slack#a_recipe_for_security
-    render json: {error: 'Invalid token'}, status: :unauthorized unless Devise.secure_compare(params[:token], ENV['SUPER_STAGING_VERIFY_TOKEN'])
+    render json: {error: 'Invalid token'}, status: :unauthorized unless params[:token] == ENV['SUPER_STAGING_VERIFY_TOKEN']
   end
 
   def parse_payload

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -4,6 +4,7 @@ class SlackController < ActionController::Base
   before_action :parse_payload, only: %i[super_staging_interactivity]
   before_action :verify_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
   before_action :initialize_super_staging, only: %i[slash_super_staging super_staging_event super_staging_interactivity]
+  skip_before_action :verify_authenticity_token
 
   def staging
 


### PR DESCRIPTION
After upgrading to Rails 5.2, I am getting an error when using the /super-staging slackbot

If you do `/super-staging list` in slack, you get the error: `/super-staging failed with the error "dispatch_failed"`

And in the staging-dashboard logs, you get this: 
```
2021-02-11T22:19:34.890668+00:00 app[web.1]: I, [2021-02-11T22:19:34.890527 #4]  INFO -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] Started POST "/slack/slash_super_staging" for 3.81.221.59 at 2021-02-11 22:19:34 +0000
2021-02-11T22:19:34.891843+00:00 app[web.1]: I, [2021-02-11T22:19:34.891759 #4]  INFO -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] Processing by SlackController#slash_super_staging as HTML
2021-02-11T22:19:34.892942+00:00 app[web.1]: I, [2021-02-11T22:19:34.892851 #4]  INFO -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5]   Parameters: {"token"=>"REDACTED", "team_id"=>"T02KV4LUK", "team_domain"=>"repairshopr", "channel_id"=>"D4UDZMQH5", "channel_name"=>"directmessage", "user_id"=>"U4UDZMK0X", "user_name"=>"jim", "command"=>"/super-staging", "text"=>"list", "api_app_id"=>"ASGFPUZRR", "is_enterprise_install"=>"false", "response_url"=>"https://hooks.slack.com/commands/T02KV4LUK/1736996972758/PAxtnvI6LLXCo5lXlPYw6OgD", "trigger_id"=>"1756400526513.2675156971.3952cba545f2901916e4321a6b37b0e0"}
2021-02-11T22:19:34.893240+00:00 app[web.1]: W, [2021-02-11T22:19:34.893173 #4]  WARN -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] Can't verify CSRF token authenticity.
2021-02-11T22:19:34.893683+00:00 app[web.1]: I, [2021-02-11T22:19:34.893621 #4]  INFO -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] Completed 422 Unprocessable Entity in 1ms (ActiveRecord: 0.0ms)
2021-02-11T22:19:34.897814+00:00 app[web.1]: F, [2021-02-11T22:19:34.897689 #4] FATAL -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5]
2021-02-11T22:19:34.897916+00:00 app[web.1]: F, [2021-02-11T22:19:34.897854 #4] FATAL -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken):
2021-02-11T22:19:34.898008+00:00 app[web.1]: F, [2021-02-11T22:19:34.897946 #4] FATAL -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5]
2021-02-11T22:19:34.898151+00:00 app[web.1]: F, [2021-02-11T22:19:34.898066 #4] FATAL -- : [76bbaafd-09ae-48b3-a966-00953fa37ff5] vendor/bundle/ruby/2.6.0/gems/actionpack-5.2.4.4/lib/action_controller/metal/request_forgery_protection.rb:211:in `handle_unverified_request'
```

I also checked in the heroku console that ENV['SUPER_STAGING_VERIFY_TOKEN'] was pulling the token correctly, and it is.
I also checked that the token in the request matched the SUPER_STAGING_VERIFY_TOKEN in Heroku, and it does. 